### PR TITLE
Remove `make` from .tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -6,7 +6,6 @@ checkov 2.3.234
 golang 1.20.4
 # renovate: datasource=github-tags depName=golangci/golangci-lint
 golangci-lint 1.52.2
-make 4.4.1
 # renovate: datasource=github-tags depName=pre-commit/pre-commit
 pre-commit 3.3.2
 terraform 1.4.6


### PR DESCRIPTION
The build harness installs make using `dnf`. Having it in the .tool-versions file makes the pre-commit pipeline choke