### PR TITLE
Update paths to paths-ignore

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -11,10 +11,8 @@ on:
       - ready_for_review
     branches:
       - main
-    paths:
-      - "**.tf"
-      - "**.go"
-      - ".github/**"
+    paths-ignore:
+      - "**.md"
 
 permissions:
   id-token: write


### PR DESCRIPTION
Lots of changes were happening that should be tested but weren't because the paths config was too constricting. This changes it to just ignore markdown-only changes.