### PR TITLE
fix: vpc endpoint policy for ecr

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,8 @@ data "aws_iam_policy_document" "ecr" {
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",
       "ecr:DescribeImages",
-      "ecr:ListImages"
+      "ecr:ListImages",
+      "ecr:PutImage"
     ]
 
     principals {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 data "aws_iam_policy_document" "ecr" {
   # checkov:skip=CKV_AWS_283: This policy allows EKS to access the regional ecr via a private VPC endpoint.
+  # checkov:skip=CKV_AWS_111: Cannot constrain down resources without knowing specific ECR Repo information.
   statement {
     effect = "Allow"
 


### PR DESCRIPTION
Added ecr:PutImage api call in vpce policy and Checkov skip for write access in policy. 

Note: I added checkov skip due to no constraining the resources for this policy. ECR repo is not known in order to add any constraints. 

First pull request I forget local pre commit. 