### PR TITLE
adding to ecr.dkr/api policy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @defenseunicorns/uds
-*.tf @defenseunicorns/delivery-aws-iac
+* @defenseunicorns/delivery-aws-iac

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To view examples for how you can leverage this VPC Module, please see the [examp
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.10.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ To view examples for how you can leverage this VPC Module, please see the [examp
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.1 |
 
-
 ## Modules
 
 | Name | Source | Version |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To view examples for how you can leverage this VPC Module, please see the [examp
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.10.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To view examples for how you can leverage this VPC Module, please see the [examp
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.1 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,10 @@ data "aws_iam_policy_document" "ecr" {
       "ecr:DescribeImages",
       "ecr:ListImages",
       "ecr:PutImage",
-      "ecr:CreateRepository"
+      "ecr:CreateRepository",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload"
     ]
 
     principals {
@@ -189,8 +192,8 @@ module "vpc_endpoints" {
       service             = "ecr.api"
       private_dns_enabled = true
       subnet_ids          = module.vpc.private_subnets
-      policy              = data.aws_iam_policy_document.ecr.json
       security_group_ids  = [aws_security_group.vpc_tls.id]
+      policy              = data.aws_iam_policy_document.ecr.json
     },
     ecr_dkr = {
       service             = "ecr.dkr"


### PR DESCRIPTION
After using this module more it was discovered that in order to use ECR properly the following need to be added to the ecr.api/dkr endpoint policy: 
```     
      "ecr:InitiateLayerUpload",
      "ecr:UploadLayerPart",
      "ecr:CompleteLayerUpload"

```
Please also take a look at issue #43 as well for more context 